### PR TITLE
Fix Landscape Images

### DIFF
--- a/app/assets/stylesheets/components/day.scss
+++ b/app/assets/stylesheets/components/day.scss
@@ -38,6 +38,12 @@
     width: var(--size);
     height: var(--size);
     z-index: 1;
+
+    img {
+      object-fit: cover;
+      width: 100%;
+      height: 100%;
+    }
   }
 
   .day__number--on-image {


### PR DESCRIPTION
The thumbnail image object fit was not properly set.

Before:
<img width="100" alt="image" src="https://github.com/user-attachments/assets/c5a8da79-4854-4a63-94d1-8f8c6bc688f3">
After:
<img width="100" alt="image" src="https://github.com/user-attachments/assets/24e8c104-c139-40bb-b3bc-c0da2959efac">